### PR TITLE
Allow games to be installed in other paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,42 @@ db_url = https://raw.githubusercontent.com/Neon68K/Automatic-Updater-Script/db/d
      archive the first time it is run.
    - On subsequent runs it will download anything that has been added from the
      last time it was run.
+   - Optionally when running `update_neon68k` you have the option to run the following
+     options when it first starts:
+     - `*Press <UP>`,    To select scaler option.
+     - `*Press <LEFT>`,  To exit.
+     - `*Press <RIGHT>`, To force a full download.
+     - `*Press <DOWN>`,  To check for updates.
 
    After that, all you need to do is sit back, relax, and enjoy.
+
+## Configuration
+
+### `GAMES_PATH`
+
+`GAMES_PATH`: by default `update_neon68k` searches the following paths in order
+to find your `games` directory; `/media/usb0`, `/media/usb1`, `/media/usb2`,
+`/media/usb3`, `/media/usb4`, `/media/usb5`, `/media/fat/cifs`, `/media/fat`.
+
+This can be overridden by setting the variable `GAMES_PATH` in `/media/fat/Scripts/update_neon68k.ini`
+eg:
+
+```ini
+GAMES_PATH=/media/fat/nfs
+```
+
+**NOTE** If your `GAMES_PATH` changes run `update_neon68k` and press `<RIGHT>`
+to force a full download to download the games to your new `GAMES_PATH`.
+
+### `scaler`
+
+Set the scaler type. The variable `scaler` should be set to in integer:
+
+- `1`: "External 4K Upscaler"
+- `2`: "MiSTer Upscaler"
+
+Example `update_neon68k.ini`:
+
+```ini
+scaler=1
+```

--- a/Scripts/update_neon68k.sh
+++ b/Scripts/update_neon68k.sh
@@ -1,19 +1,42 @@
 #!/bin/bash
 
+# TODO
+# * update games when files are missing or the media_path has changed
+# * allow filtering of game categories and games
+
 ARCHIVE_ID="neon68k"
+NEON68K_VERSION="Neon68K-20250428"
+
 DEST_DIR="/media/fat"
 TMP_DIR="/tmp/neon68k"
 ARCHIVE_METADATA="${TMP_DIR}/metadata.json"
-CONFIG_DIR="${DEST_DIR}/Scripts/.config/neon68k"
+SCRIPTS_DIR="${DEST_DIR}/Scripts"
+CONFIG_DIR="${SCRIPTS_DIR}/.config/neon68k"
 LASTRUN_FILE="${CONFIG_DIR}/lastrun.txt"
-SCRIPT_INI="${DEST_DIR}/Scripts/update_neon68k.ini"
+SCRIPT_INI="${SCRIPTS_DIR}/update_neon68k.ini"
 
-NEON68K_VERSION=Neon68K-20250428
+# Paths to check for games directory
+MEDIA_PATHS=(
+  '/media/usb0'
+  '/media/usb1'
+  '/media/usb2'
+  '/media/usb3'
+  '/media/usb4'
+  '/media/usb5'
+  '/media/fat/cifs'
+  '/media/fat'
+)
 
-[[ -e "${DEST_DIR}" ]]   || mkdir -p "$DEST_DIR"
-[[ -e "${TMP_DIR}" ]]    || mkdir -p "$TMP_DIR"
+for media_path in "${MEDIA_PATHS[@]}"; do
+  if [ -e "${media_path}/games" ]; then
+    GAMES_PATH="${media_path}"
+    break
+  fi
+done
+
+[[ -e "${DEST_DIR}"   ]] || mkdir -p "$DEST_DIR"
+[[ -e "${TMP_DIR}"    ]] || mkdir -p "$TMP_DIR"
 [[ -e "${CONFIG_DIR}" ]] || mkdir -p "${CONFIG_DIR}"
-
 [[ -f "${SCRIPT_INI}" ]] && source "${SCRIPT_INI}"
 
 # Function to get values from an ini file
@@ -27,7 +50,8 @@ ini_get() {
 ini_set() {
   ! [ -f ${SCRIPT_INI} ] && touch ${SCRIPT_INI}
 
-  val="$(ini_get ${1} ${2})"
+  local val
+  val="$(ini_get "${1}" "${2}")"
 
   if [[ -z "${val}" ]]; then
     echo "${1}=${2}" >> ${SCRIPT_INI}
@@ -38,6 +62,18 @@ ini_set() {
   source ${SCRIPT_INI}
 }
 
+get_scaler() {
+  # The first item in this array is empty. Due to historical reasons the scalers
+  # list in the scaler dialog command started at 1 but arrays start at 0
+
+  # The scaler names in this array match up with the directory names in the archive
+  local scalers=(
+    ""
+    "External 4K Upscaler"
+    "MiSTer Upscaler"
+  )
+  echo "${scalers[${1}]}"
+}
 
 # Function to URL-encode file paths
 url_encode() {
@@ -86,7 +122,7 @@ sync_files() {
 
     if [ "$full_download" -eq 0 ]; then
         last_run=$(cat "$LASTRUN_FILE" 2>/dev/null || echo 0)
-        echo "Performing incremental sync since: $(date -d @"${last_run}")"
+        echo -n "Performing incremental sync"
     fi
 
     while IFS= read -r file; do
@@ -95,7 +131,7 @@ sync_files() {
         if [ "$full_download" -eq 0 ]; then
             mod_time=$(jq --arg file "${file}" -r '.files[] | select(.name==$file) | .mtime' < $ARCHIVE_METADATA)
             if [[ -n "$mod_time" && "$mod_time" -le "$last_run" ]]; then
-                echo "Skipping (not newer): $file"
+                echo -n .
                 continue
             fi
         fi
@@ -108,22 +144,46 @@ sync_files() {
             continue
         fi
 
-        unzip -q -o "$TMP_DIR/tmp.zip" -d "$TMP_DIR"
-
-        for dir in "_Computer" "config" "games"; do
-            if [ -d "$TMP_DIR/$dir" ]; then
-                echo "Copying $dir to $DEST_DIR"
-                cp -r "$TMP_DIR/$dir" "$DEST_DIR"
-            fi
+        for dir in "_Computer" "config"; do
+            echo "Copying $dir to $DEST_DIR"
+            unzip -q -o "$TMP_DIR/tmp.zip" "${dir}/*" -d "$DEST_DIR"
         done
 
+        echo "Copying games to ${GAMES_PATH}"
+        unzip -q -o "$TMP_DIR/tmp.zip" "games/*" -d "${GAMES_PATH}"
+
         rm -f "$TMP_DIR/tmp.zip"
-        rm -rf "$TMP_DIR/_Computer" "$TMP_DIR/config" "$TMP_DIR/games"
 
     done <<< "$file_list"
+    echo
 
     date +%s > "$LASTRUN_FILE"
     rm -f ${ARCHIVE_METADATA}
+}
+
+choose_scaler() {
+  local old_scaler
+  old_scaler=$(ini_get scaler)
+
+  # Show dialog prompt for scaler type
+  dialog \
+    --clear \
+    --title "Select Scaler Type" \
+    --menu "Choose your display scaler:" 10 50 2 \
+      1 "$(get_scaler 1)" \
+      2 "$(get_scaler 2)" \
+    2> "$TMP_DIR/scaler_choice.txt"
+
+  ini_set scaler "$(cat "$TMP_DIR/scaler_choice.txt" 2>/dev/null)"
+  rm -f "$TMP_DIR/scaler_choice.txt"
+
+  clear -x
+  echo "$(get_scaler "$(ini_get scaler)") selected"
+
+  if [ "${old_scaler}" != "$(ini_get scaler)" ]; then
+    echo "Scaler setting has changed, performing full download..."
+    full_download=1
+  fi
 }
 
 main_dialog() {
@@ -134,25 +194,70 @@ main_dialog() {
   fi
 
   if [[ -z "$(ini_get scaler)" ]]; then
-    # Show dialog prompt for scaler type
-    dialog \
-      --clear \
-      --title "Select Scaler Type" \
-      --menu "Choose your display scaler:" 10 50 2 \
-        1 "External 4K Upscaler" \
-        2 "MiSTer Upscaler" \
-      2> "$TMP_DIR/scaler_choice.txt"
-
-    ini_set scaler "$(cat "$TMP_DIR/scaler_choice.txt" 2>/dev/null)"
-    rm -f "$TMP_DIR/scaler_choice.txt"
+    choose_scaler
   fi
 
   # Determine scaler path
-  if [ "$(ini_get scaler)" == "1" ]; then
-      scaler_dir="External 4K Upscaler"
-  else
-      scaler_dir="MiSTer Upscaler"
+  scaler_dir="$(get_scaler "$(ini_get scaler)")"
+
+  echo "
+               _   __                     _____  ____   __ __
+              / | / /___   ____   ____   / ___/ ( __ ) / //_/
+             /  |/ // _ \ / __ \ / __ \ / __ \ / __  |/ ,<
+            / /|  //  __// /_/ // / / // /_/ // /_/ // /| |
+           /_/ |_/ \___/ \____//_/ /_/ \____/ \____//_/ |_|
+
+        Neon68K - the easiest X68000 games setup for MiSTer FPGA
+
+Launching update_neon68k...
+
+Current settings:
+  * Games install path: ${GAMES_PATH}/games
+  * Scaler: ${scaler_dir}
+"
+  if [[ -f ${LASTRUN_FILE} ]]; then
+        echo "update_neon68k was last run $(date -d @"$(cat ${LASTRUN_FILE})")"
   fi
+  echo "
+  *Press <UP>,    To select scaler option.
+  *Press <LEFT>,  To exit.
+  *Press <RIGHT>, To force a full download.
+  *Press <DOWN>,  To check for updates.
+
+Waiting for 10 seconds then we'll automatically check for updates...
+"
+
+  while true; do
+    escape_char=$(printf "\u1b")
+    read -t 10 -rsn1 mode # get 1 character
+
+    # If it times out we break out and carry on to sync_files
+    [[ $? -gt 128 ]] && break
+
+    if [[ $mode == "$escape_char" ]]; then
+      read -rsn2 mode     # read 2 more chars
+    fi
+
+    case $mode in
+      '[A') # Up
+          choose_scaler
+          break
+        ;;
+      '[B') # Down
+          echo Checking for updates
+          break
+        ;;
+      '[C') # Right
+          echo "Running a full download"
+          full_download=1
+          break
+        ;;
+      '[D') # Left
+        echo Exiting
+        exit 0
+        ;;
+    esac
+  done
 }
 
 main_dialog


### PR DESCRIPTION
* Allow games to be installed in other paths
  * By default it will search the default paths, and whichever one has the `games` directory in it will be where the hdf files will be installed
  * Users can optionally override this by setting their own `GAMES_PATH` in `update_neon68k.ini`
  * I don't have a nice way of at the moment of detecting the game path has changed, so for now users can run a `force full download` to download everything again to the right location
* Add option to change scaler
* Force full download
* When update_neon is run the user is given the option to select scaler, exit, force full download or incremental update. If there's no user input after 10 seconds it will do an incremental update



```

               _   __                     _____  ____   __ __
              / | / /___   ____   ____   / ___/ ( __ ) / //_/
             /  |/ // _ \ / __ \ / __ \ / __ \ / __  |/ ,<
            / /|  //  __// /_/ // / / // /_/ // /_/ // /| |
           /_/ |_/ \___/ \____//_/ /_/ \____/ \____//_/ |_|

        Neon68K - the easiest X68000 games setup for MiSTer FPGA

Launching update_neon68k...

Current settings:
  * Games install path: /media/fat/cifs/games
  * Scaler: External 4K Upscaler

update_neon68k was last run Wed 11 Jun 2025 08:37:17 AM PDT

  *Press <UP>,    To select scaler option.
  *Press <LEFT>,  To exit.
  *Press <RIGHT>, To force a full download.
  *Press <DOWN>,  To check for updates.

Waiting for 10 seconds then we'll automatically check for updates...

Checking for updates
Fetching archive metadata...
Starting sync...
Fetching file list...
Performing incremental sync.................................................................................................................................................................................................................................................................................
Sync complete.
Done.
```